### PR TITLE
Databricks - Add Public Network Check for deploying IP access lists

### DIFF
--- a/terraform/databricks/main.tf
+++ b/terraform/databricks/main.tf
@@ -96,7 +96,7 @@ resource "databricks_workspace_conf" "adb_ws_conf" {
   }
   depends_on = [azurerm_databricks_workspace.adl_databricks[0]]
 
-  count = var.module_enabled ? 1 : 0
+  count = var.module_enabled && var.public_network_enabled ? 1 : 0
 }
 
 resource "databricks_ip_access_list" "adb_ws_allow-list" {
@@ -106,7 +106,7 @@ resource "databricks_ip_access_list" "adb_ws_allow-list" {
   ip_addresses = var.allow_ip_list
   depends_on   = [databricks_workspace_conf.adb_ws_conf]
 
-  count = var.module_enabled && var.enable_ip_access_list && length(var.allow_ip_list) > 0 ? 1 : 0
+  count = var.module_enabled && var.public_network_enabled && var.enable_ip_access_list && length(var.allow_ip_list) > 0 ? 1 : 0
 }
 
 resource "databricks_ip_access_list" "adb_ws_block-list" {
@@ -116,5 +116,5 @@ resource "databricks_ip_access_list" "adb_ws_block-list" {
   ip_addresses = var.block_ip_list
   depends_on   = [databricks_workspace_conf.adb_ws_conf]
 
-  count = var.module_enabled && var.enable_ip_access_list && length(var.block_ip_list) > 0 ? 1 : 0
+  count = var.module_enabled && var.public_network_enabled && var.enable_ip_access_list && length(var.block_ip_list) > 0 ? 1 : 0
 }


### PR DESCRIPTION
According to Databricks [docs](https://learn.microsoft.com/en-us/azure/databricks/security/network/ip-access-list) 

> IP access lists apply only to requests over the internet (public IP addresses)

So, if public network access is disabled, and hence all network traffic to the workspace is private (through private endpoints), IP access list don't apply, and should be skipped.