### PR TITLE
Enable external PRs for Storage Account Module

### DIFF
--- a/.github/workflows/storage-account.yml
+++ b/.github/workflows/storage-account.yml
@@ -12,10 +12,6 @@ on:
 env:
   terraform_workingdir: "terraform/storage-account"  
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
 jobs:     
   terraform-lint:
@@ -51,7 +47,9 @@ jobs:
     name: Run Terratest
     needs: 
       - terraform-sec
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=azure-data-labs-modules]
+    environment:
+      name: acctests
 
     defaults:
           run:
@@ -67,14 +65,26 @@ jobs:
           go-version: 1.18.2
       
     - name: Setup Dependencies
-      run:  go mod init test && go mod tidy
+      run:  |
+        az login --identity > /dev/null
+        export ARM_USE_MSI=true
+        export ARM_SUBSCRIPTION_ID=$(az login --identity | jq -r '.[0] | .id')
+        export ARM_TENANT_ID=$(az login --identity | jq -r '.[0] | .tenantId')
+        export HA_SUBNET_ID=$(az keyvault secret show --name Agent-Pool-Subnet-Id --vault-name adl-modules-akv --query value -o tsv)
+        go mod init test && go mod tidy
       env:
-        GOPATH: "/home/runner/work/azure-labs-modules/azure-labs-modules/${{ env.terraform_workingdir }}"
+        GOPATH: "/home/cloudtest/work/azure-labs-modules/azure-labs-modules/${{ env.terraform_workingdir }}"
       
     - name: Unit-test
-      run: go test -v -timeout 45m
+      run:  |
+        az login --identity > /dev/null
+        export ARM_USE_MSI=true
+        export ARM_SUBSCRIPTION_ID=$(az login --identity | jq -r '.[0] | .id')
+        export ARM_TENANT_ID=$(az login --identity | jq -r '.[0] | .tenantId')
+        export HA_SUBNET_ID=$(az keyvault secret show --name Agent-Pool-Subnet-Id --vault-name adl-modules-akv --query value -o tsv)
+        go test -v -timeout 45m
       env:
-        GOPATH: "/home/runner/work/azure-labs-modules/azure-labs-modules/${{ env.terraform_workingdir }}"
+        GOPATH: "/home/cloudtest/work/azure-labs-modules/azure-labs-modules/${{ env.terraform_workingdir }}"
 
   terraform-docs:
     name: Run Terraform Docs

--- a/terraform/storage-account/test/unit_test.go
+++ b/terraform/storage-account/test/unit_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
+	"os"
 )
 
 func TestModule(t *testing.T) {
@@ -14,6 +15,9 @@ func TestModule(t *testing.T) {
 		Lock: true,
 		LockTimeout: "1800s",
 		// VarFiles: []string{"terraform_unitest.tfvars"},
+		Vars: map[string]interface{}{
+            "firewall_virtual_network_subnet_ids": []string{os.Getenv("HA_SUBNET_ID")},
+        },
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created


### PR DESCRIPTION
Secure the workflow using Hosted Pools and Managed Identities to allow PR from forks to run tests.
Subnet Id from the hosted agent stored in Key Vault for whitelisting in the storage account firewall