### PR TITLE
Add preconditions to check configuration compatibility

### DIFF
--- a/terraform/databricks/main.tf
+++ b/terraform/databricks/main.tf
@@ -96,7 +96,14 @@ resource "databricks_workspace_conf" "adb_ws_conf" {
   }
   depends_on = [azurerm_databricks_workspace.adl_databricks[0]]
 
-  count = var.module_enabled && var.public_network_enabled ? 1 : 0
+  count = var.module_enabled && var.enable_ip_access_list ? 1 : 0
+
+  lifecycle {
+    precondition {
+        condition     = (var.enable_ip_access_list == var.public_network_enabled)
+        error_message = "IP access lists apply only to requests over the internet"
+    }
+  }
 }
 
 resource "databricks_ip_access_list" "adb_ws_allow-list" {
@@ -106,7 +113,7 @@ resource "databricks_ip_access_list" "adb_ws_allow-list" {
   ip_addresses = var.allow_ip_list
   depends_on   = [databricks_workspace_conf.adb_ws_conf]
 
-  count = var.module_enabled && var.public_network_enabled && var.enable_ip_access_list && length(var.allow_ip_list) > 0 ? 1 : 0
+  count = var.module_enabled && var.enable_ip_access_list && length(var.allow_ip_list) > 0 ? 1 : 0
 }
 
 resource "databricks_ip_access_list" "adb_ws_block-list" {
@@ -116,5 +123,5 @@ resource "databricks_ip_access_list" "adb_ws_block-list" {
   ip_addresses = var.block_ip_list
   depends_on   = [databricks_workspace_conf.adb_ws_conf]
 
-  count = var.module_enabled && var.public_network_enabled && var.enable_ip_access_list && length(var.block_ip_list) > 0 ? 1 : 0
+  count = var.module_enabled && var.enable_ip_access_list && length(var.block_ip_list) > 0 ? 1 : 0
 }

--- a/terraform/databricks/main.tf
+++ b/terraform/databricks/main.tf
@@ -23,13 +23,13 @@ resource "azurerm_databricks_workspace" "adl_databricks" {
 
   lifecycle {
     precondition {
-        condition     = (var.is_sec_module || var.public_network_enabled)
-        error_message = "Deny public access requiries a private link endpoint (is_sec_module set to 'true')"
+      condition     = (var.is_sec_module || var.public_network_enabled)
+      error_message = "Deny public access requiries a private link endpoint (is_sec_module set to 'true')"
     }
 
     precondition {
-        condition     = (!var.enable_ip_access_list || var.public_network_enabled)
-        error_message = "IP access lists apply only to requests over the internet (public_network_enabled set to 'true')"
+      condition     = (!var.enable_ip_access_list || var.public_network_enabled)
+      error_message = "IP access lists apply only to requests over the internet (public_network_enabled set to 'true')"
     }
   }
 }
@@ -56,8 +56,8 @@ resource "azurerm_private_endpoint" "databricks_pe_be" {
 
   lifecycle {
     precondition {
-        condition     = (var.is_sec_module && var.maximum_network_security)
-        error_message = "'maximum_network_security' is only available on 'sec_module' set to 'true'"
+      condition     = (var.is_sec_module && var.maximum_network_security)
+      error_message = "'maximum_network_security' is only available on 'sec_module' set to 'true'"
     }
   }
 }


### PR DESCRIPTION
Remove configuration compatibility from resource enablement and add preconditions to check that compatibility.
This makes the module variables more aligned with resource properties and provides more helpful messages to users about failed configuration