### PR TITLE
Disable load_balancer_backend_address_pool_id property in Databricks module

### DIFF
--- a/terraform/databricks/databricks-workspace/main.tf
+++ b/terraform/databricks/databricks-workspace/main.tf
@@ -15,7 +15,8 @@ resource "azurerm_databricks_workspace" "adl_databricks" {
   managed_disk_cmk_rotation_to_latest_version_enabled = var.managed_disk_cmk_rotation_to_latest_version_enabled
   public_network_access_enabled                       = var.public_network_access_enabled
   network_security_group_rules_required               = var.is_private_endpoint ? "NoAzureDatabricksRules" : "AllRules"
-  load_balancer_backend_address_pool_id               = var.load_balancer_backend_address_pool_id
+  # Disabling due to https://github.com/Azure/azure-data-labs-modules/issues/227
+  #load_balancer_backend_address_pool_id               = var.load_balancer_backend_address_pool_id
   custom_parameters {
     nat_gateway_name                                     = var.nat_gateway_name
     public_ip_name                                       = var.public_ip_name

--- a/terraform/databricks/databricks-workspace/variables.tf
+++ b/terraform/databricks/databricks-workspace/variables.tf
@@ -230,7 +230,7 @@ variable "managed_disk_cmk_rotation_to_latest_version_enabled" {
 
 variable "load_balancer_backend_address_pool_id" {
   type        = string
-  description = "Resource ID of the Outbound Load balancer Backend Address Pool for Secure Cluster Connectivity (No Public IP) workspace. Changing this forces a new resource to be created."
+  description = "Resource ID of the Outbound Load balancer Backend Address Pool for Secure Cluster Connectivity (No Public IP) workspace. Changing this forces a new resource to be created. This property is currently disabled and has no effect."
   default     = null
 }
 


### PR DESCRIPTION
It is not possible to currently provide a neutral value for this property that has no effect on the workspace.
When provided to null or empty string, workspace deployment is a success, but cluster creation fails with bootstrap error.
When this value is not provided, the workspace behaves correctly.

Since this is a very specific and uncommon property to use, we should disable it in order to provide a quick and effective solution.