### PR TITLE
Rename cmk resource in test

### DIFF
--- a/terraform/databricks/databricks-workspace/test/databricks.tf
+++ b/terraform/databricks/databricks-workspace/test/databricks.tf
@@ -32,7 +32,7 @@ resource "time_sleep" "time_sleep" {
   create_duration = "40s"
 }
 
-resource "azurerm_databricks_workspace_customer_managed_key" "adl_adb_ws_cmk" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "adl_adb_ws_cmk" {
   depends_on = [
     azurerm_key_vault_access_policy.databricks,
     time_sleep.time_sleep

--- a/terraform/databricks/databricks-workspace/test/outputs.tf
+++ b/terraform/databricks/databricks-workspace/test/outputs.tf
@@ -15,5 +15,5 @@ output "resource_group_name" {
 }
 
 output "cmk_id" {
-  value = azurerm_databricks_workspace_customer_managed_key.adl_adb_ws_cmk.id
+  value = azurerm_databricks_workspace_root_dbfs_customer_managed_key.adl_adb_ws_cmk.id
 }

--- a/terraform/databricks/databricks-workspace/test/providers.tf
+++ b/terraform/databricks/databricks-workspace/test/providers.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "= 3.67.0"
+      version = "= 3.97.1"
     }
     databricks = {
       source  = "databricks/databricks"


### PR DESCRIPTION
rename azurerm_databricks_workspace_customer_managed_key resource for azurerm_databricks_workspace_root_dbfs_customer_managed_key in tests as it is deprecated and become unavailable by version 4.0 of the provider