### PR TITLE
Change test region of CosmosDB modules

### DIFF
--- a/terraform/cosmosdb/cosmosdb-account/test/variables.tf
+++ b/terraform/cosmosdb/cosmosdb-account/test/variables.tf
@@ -6,7 +6,7 @@ resource "random_string" "postfix" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = "West US"
 }
 
 variable "kind" {

--- a/terraform/cosmosdb/cosmosdb-cassandra-keyspace/test/variables.tf
+++ b/terraform/cosmosdb/cosmosdb-cassandra-keyspace/test/variables.tf
@@ -6,5 +6,5 @@ resource "random_string" "postfix" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = "West US"
 }

--- a/terraform/cosmosdb/cosmosdb-gremlin-database/test/variables.tf
+++ b/terraform/cosmosdb/cosmosdb-gremlin-database/test/variables.tf
@@ -6,5 +6,5 @@ resource "random_string" "postfix" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = "West US"
 }

--- a/terraform/cosmosdb/cosmosdb-mongo-database/test/variables.tf
+++ b/terraform/cosmosdb/cosmosdb-mongo-database/test/variables.tf
@@ -6,5 +6,5 @@ resource "random_string" "postfix" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = "West US"
 }

--- a/terraform/cosmosdb/cosmosdb-sql-database/test/variables.tf
+++ b/terraform/cosmosdb/cosmosdb-sql-database/test/variables.tf
@@ -6,5 +6,5 @@ resource "random_string" "postfix" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = "West US"
 }

--- a/terraform/cosmosdb/cosmosdb-table/test/variables.tf
+++ b/terraform/cosmosdb/cosmosdb-table/test/variables.tf
@@ -6,5 +6,5 @@ resource "random_string" "postfix" {
 
 variable "location" {
   type    = string
-  default = "West Europe"
+  default = "West US"
 }


### PR DESCRIPTION
change it due to temporary constraints in the west Europe region